### PR TITLE
Coroutine game controller

### DIFF
--- a/pyndemic.py
+++ b/pyndemic.py
@@ -2,18 +2,40 @@
 # coding: utf-8
 import sys
 
-from src.controller import MainController
+from src.controller import GameController
 
 
 __version__ = "0.1.0"
 
 
-if __name__ == '__main__':
-    cli_args = sys.argv[1:]
+def main(args):
+    default_stdin = sys.stdin
 
-    input_file = cli_args[0] if cli_args else None
-    random_state = int(cli_args[1]) if cli_args[1:] else None
+    input_file = args[0] if args else None
+    random_state = int(args[1]) if args[1:] else None
 
-    controller = MainController(input_file, random_state)
+    if input_file:
+        sys.stdin = open(input_file, 'r')
+    controller = GameController(random_state)
     controller.run()
 
+    while True:
+        try:
+            command = sys.stdin.readline().rstrip()
+        except EOFError:
+            sys.stdin = default_stdin
+            continue
+        except KeyboardInterrupt:
+            print('You decided to exit the game...')
+            command = 'quit'
+
+        response = controller.send(command)
+        print(response)
+
+        if response['type'] == 'termination':
+            break
+
+
+if __name__ == '__main__':
+    cli_args = sys.argv[1:]
+    main(cli_args)

--- a/src/controller.py
+++ b/src/controller.py
@@ -17,11 +17,14 @@ class AbstractController(ABC):
         return self
 
     def __exit__(self, exc_type, exc_val, exc_tb):
-        pass
+        self.stop()
 
     @abstractmethod
     def run(self):
         pass
+
+    def stop(self):
+        self._loop.close()
 
     def send(self, command):
         return self._loop.send(command)

--- a/src/controller.py
+++ b/src/controller.py
@@ -2,6 +2,7 @@
 import itertools as its
 import random
 import logging
+from abc import ABC, abstractmethod
 
 from .game import *
 from .city import NoDiseaseInCityException
@@ -10,7 +11,18 @@ from . import log
 from .commands import COMMANDS
 
 
-class BaseController:
+class AbstractController(ABC):
+    def __enter__(self):
+        self.run()
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        pass
+
+    @abstractmethod
+    def run(self):
+        pass
+
     def send(self, command):
         return self._loop.send(command)
 
@@ -30,7 +42,7 @@ class BaseController:
         return final_response
 
 
-class GameController(BaseController):
+class GameController(AbstractController):
     def __init__(self, random_state=None):
         self.game = None
         self.players = {}

--- a/src/controller.py
+++ b/src/controller.py
@@ -8,21 +8,36 @@ from .city import NoDiseaseInCityException
 from .player import LastDiseaseCuredException
 from . import log
 from .commands import COMMANDS
-from .api import HybridInputManager
 
 
-class MainController:
-    def __init__(self, input_file=None, random_state=None):
-        if input_file is not None:
-            self.input = HybridInputManager('file', input_file)
-        else:
-            self.input = HybridInputManager()
+class BaseController:
+    def send(self, command):
+        return self._loop.send(command)
 
+    def throw(self, exception):
+        self._loop.throw(exception)
+
+    def empty_response(self):
+        return {
+            'type': 'empty',
+        }
+
+    def final_response(self, message):
+        final_response = {
+            'type': 'termination',
+            'message': message,
+        }
+        return final_response
+
+
+class GameController(BaseController):
+    def __init__(self, random_state=None):
         self.game = None
         self.players = {}
         self.current_player = None
-
         self.name_cycle = None
+        self._loop = None
+
         if random_state is not None:
             random.seed(random_state)
             logging.info(
@@ -34,24 +49,8 @@ class MainController:
 
     def run(self):
         self.start_game(['Alpha', 'Bravo', 'Charlie', 'Delta'])
-        try:
-            while True:
-                command = self.input()
-                if not command:
-                    continue
-
-                self.run_single_command(command)
-        except LastDiseaseCuredException as e:
-            logging.warning(e)
-            logging.warning('Game won!')
-        except GameCrisisException as e:
-            logging.warning(e)
-            logging.warning('Game lost!')
-        except KeyboardInterrupt:
-            logging.warning(
-                'You decided to exit the game...')
-
-        logging.info('---<<< Thats all! >>>---')
+        self._loop = self.game_loop()
+        self._loop.send(None)
 
     def start_game(self, player_names):
         logging.info(
@@ -68,14 +67,30 @@ class MainController:
         self.game.start_game()
         self._switch_player()
 
-    def _switch_player(self):
-        self.current_player = self.players[next(self.name_cycle)]
-        logging.info(
-            f'Active player: {self.current_player.name}')
+    def send(self, command):
+        if command == 'quit':
+            return self.final_response('---<<< That\'s all! >>>---')
+        try:
+            return self._loop.send(command)
+        except LastDiseaseCuredException as e:
+            logging.warning(e)
+            logging.warning('Game won!')
+        except GameCrisisException as e:
+            logging.warning(e)
+            logging.warning('Game lost!')
 
-        self.game.start_turn(self.current_player)
-        logging.info(
-            f'Actions left: {self.current_player.action_count}')
+        return self.final_response('---<<< That\'s all! >>>---')
+
+    def game_loop(self):
+        response = None
+        while True:
+            command = yield response
+            if not command:
+                response = self.empty_response()
+                continue
+
+            self.run_single_command(command)
+            response = self.empty_response()
 
     def run_single_command(self, command):
         logging.debug(
@@ -121,3 +136,12 @@ class MainController:
             'Infect phase gone. Starting new turn.')
 
         self._switch_player()
+
+    def _switch_player(self):
+        self.current_player = self.players[next(self.name_cycle)]
+        logging.info(
+            f'Active player: {self.current_player.name}')
+
+        self.game.start_turn(self.current_player)
+        logging.info(
+            f'Actions left: {self.current_player.action_count}')

--- a/test/test_controller.py
+++ b/test/test_controller.py
@@ -3,16 +3,22 @@ import unittest
 from unittest import TestCase, skip, expectedFailure
 
 import os.path as op
+import os
+import sys
 
-from src.controller import MainController
+from src.controller import GameController
+from pyndemic import main
 
 
 INPUT_LOCATION = op.join(op.dirname(__file__), 'test_input.txt')
 
 
 # TODO: expand test case for controller
-class MainControllerTestCase(TestCase):
+class GameControllerTestCase(TestCase):
     def test_run(self):
-        self.controller = MainController(INPUT_LOCATION, 42)
-        self.controller.run()
-
+        stdout, sys.stdout = sys.stdout, open(os.devnull, 'w')
+        try:
+            with sys.stdout:
+                main([INPUT_LOCATION, 42])
+        finally:
+            sys.stdout = stdout

--- a/test/test_controller.py
+++ b/test/test_controller.py
@@ -7,7 +7,6 @@ import os
 import sys
 
 from src.controller import GameController
-from pyndemic import main
 
 
 INPUT_LOCATION = op.join(op.dirname(__file__), 'test_input.txt')

--- a/test/test_controller.py
+++ b/test/test_controller.py
@@ -15,10 +15,18 @@ INPUT_LOCATION = op.join(op.dirname(__file__), 'test_input.txt')
 
 # TODO: expand test case for controller
 class GameControllerTestCase(TestCase):
-    def test_run(self):
+    def test_game_session(self):
         stdout, sys.stdout = sys.stdout, open(os.devnull, 'w')
+        stdin, sys.stdin = sys.stdin, open(INPUT_LOCATION, 'r')
+        random_state = 42
+        controller = GameController(random_state)
+
         try:
-            with sys.stdout:
-                main([INPUT_LOCATION, 42])
+            with sys.stdout, sys.stdin, controller:
+                while True:
+                    command = sys.stdin.readline().rstrip()
+                    response = controller.send(command)
+                    if response['type'] == 'termination':
+                        break
         finally:
-            sys.stdout = stdout
+            sys.stdout, sys.stdin = stdout, stdin


### PR DESCRIPTION
The game controller now works as a coroutine maintaining internal game loop and yielding responses on received commands.

Code example:

```python
controller = GameController()

# Create internal game object and initiate game loop
controller.run()

# Send a command and get a response (for now, all regular responses are empty)
response = controller.send(command)
print(response)  # {'type': 'empty'}

# Terminate with 'quit' command and get the final response
response = controller.send('quit')
print(response)  # {'type': 'termination', ... }

# Stop game loop - after that, no command sendings allowed
controller.stop()
```

It is possible to use context manager syntax without explicit `.run` and `.stop` calls:

```python
with GameController() as controller:
    response = controller.send(command)
```

These changes are prepared for upcoming console UI and future backend operations.