### PR TITLE
Feature/manual game setup

### DIFF
--- a/pyndemic/config.py
+++ b/pyndemic/config.py
@@ -1,4 +1,5 @@
 import os
+from copy import deepcopy
 from configparser import ConfigParser
 
 
@@ -15,7 +16,7 @@ def get_settings(settings_location=None, *, refresh=False):
     if refresh or _CACHED_SETTINGS is None:
         refresh_settings(settings_location)
 
-    app_config = _CACHED_SETTINGS
+    app_config = deepcopy(_CACHED_SETTINGS)
     return app_config
 
 

--- a/pyndemic/game.py
+++ b/pyndemic/game.py
@@ -2,7 +2,6 @@ import logging
 
 from collections import OrderedDict
 
-from . import config
 from .exceptions import GameCrisisException
 from .core import GameEntity
 from .city import City
@@ -37,8 +36,8 @@ class Game(GameEntity):
         self.settings = None
         self.active_character = None
 
-    def setup_game(self, settings_location=None):
-        self.settings = config.get_settings(settings_location)
+    def setup_game(self, settings):
+        self.settings = settings
         self.get_infection_rate()
         self.get_new_diseases()
         self.get_new_city_map()

--- a/test/test_character.py
+++ b/test/test_character.py
@@ -23,7 +23,7 @@ class CharacterTestCase(TestCase):
         self.other_character = Character('Bob')
         self.game.add_character(self.character)
         self.game.add_character(self.other_character)
-        self.game.setup_game(SETTINGS_LOCATION)
+        self.game.setup_game(self.settings)
 
     def test_init(self):
         character = Character('Bob')

--- a/test/test_config.py
+++ b/test/test_config.py
@@ -30,13 +30,14 @@ class ConfigModuleTestCase(TestCase):
         settings = config.get_settings(SETTINGS_LOCATION)
 
         self.assertIsNotNone(config._CACHED_SETTINGS)
-        self.assertIs(config._CACHED_SETTINGS, settings)
+        self.assertIsNot(config._CACHED_SETTINGS, settings)
+        self.assertEqual(config._CACHED_SETTINGS, settings)
 
         settings_again = config.get_settings(SETTINGS_LOCATION)
-        self.assertIs(settings, settings_again)
+        self.assertEqual(settings, settings_again)
 
         settings_reloaded = config.get_settings(SETTINGS_LOCATION, refresh=True)
-        self.assertIs(config._CACHED_SETTINGS, settings_reloaded)
+        self.assertEqual(config._CACHED_SETTINGS, settings_reloaded)
         self.assertIsNot(settings_reloaded, settings)
         self.assertEqual(settings['Cities']['city9'],
                          settings_reloaded['Cities']['city9'])

--- a/test/test_controller.py
+++ b/test/test_controller.py
@@ -1,4 +1,4 @@
-from unittest import TestCase, skip
+from unittest import TestCase
 from unittest.mock import patch, Mock, MagicMock
 
 from io import StringIO
@@ -6,12 +6,11 @@ import os.path as op
 
 from pyndemic.game import ExhaustedPlayerDeckException
 from pyndemic.character import LastDiseaseCuredException
-
 from pyndemic.core import api
-
 from pyndemic.ui.console import ConsoleUI
 from pyndemic.controller import GameController
 from pyndemic.core.context import _ContextManager
+
 
 INPUT_LOCATION = op.join(op.dirname(__file__), 'test_input.txt')
 
@@ -37,7 +36,8 @@ class GameControllerTestCase(TestCase):
         singleton_game_instance = MagicMock()
         game_class.return_value = singleton_game_instance
 
-        self.controller.start_game(["A", "B"])
+        self.controller.setup({'players': ['A', 'B']})
+        self.controller.start_game()
 
         # test that Game setup methods called
         self.assertIs(singleton_game_instance, self.controller.game)
@@ -50,7 +50,8 @@ class GameControllerTestCase(TestCase):
     @patch('pyndemic.controller.Game')
     def test_send(self, game_class):
         with patch("pyndemic.controller.GameController.emit_signal") as emit:
-            self.controller.start_game(["A", "B"])
+            self.controller.setup({'players': ['A', 'B']})
+            self.controller.start_game()
             self.controller._loop = Mock()
 
             # test LastDiseaseCuredException
@@ -91,7 +92,8 @@ class GameControllerTestCase(TestCase):
 
     @patch('pyndemic.controller.Game')
     def test_switch_player(self, game_class):
-        self.controller.start_game(["A", "B"])
+        self.controller.setup({'players': ['A', 'B']})
+        self.controller.start_game()
         active_player = self.controller.current_character
         self.controller._switch_character()
         new_player = self.controller.current_character

--- a/test/test_formatter.py
+++ b/test/test_formatter.py
@@ -28,7 +28,7 @@ class GameStateSerialisationCase(unittest.TestCase):
         self.pg = Game()
         self.pg.add_character(self.character1)
         self.pg.add_character(self.character2)
-        self.pg.setup_game(SETTINGS_LOCATION)
+        self.pg.setup_game(self.settings)
         self.pg.start_game()
 
         top_player_card = self.pg.player_deck.take_top_card()
@@ -127,12 +127,16 @@ class DiseaseSerialisationTestCase(unittest.TestCase):
 
 
 class CharacterSerialisationTestCase(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.settings = config.get_settings(SETTINGS_LOCATION, refresh=True)
+
     def setUp(self):
         random.seed(42)
         self.game = Game()
         self.character = Character('Alice')
         self.game.add_character(self.character)
-        self.game.setup_game(SETTINGS_LOCATION)
+        self.game.setup_game(self.settings)
         self.character.set_location('London')
         self.character.action_count = 4
         self.character.hand = [PlayerCard('London', 'Blue'),

--- a/test/test_game.py
+++ b/test/test_game.py
@@ -105,7 +105,7 @@ class GameSetupTestCase(TestCase):
         for character in characters:
             self.pg.add_character(character)
 
-        self.pg.setup_game(SETTINGS_LOCATION)
+        self.pg.setup_game(self.settings)
 
         self.assertEqual(self.pg.settings, self.settings)
 
@@ -136,6 +136,10 @@ class GameSetupTestCase(TestCase):
 
 
 class GameTestCase(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.settings = config.get_settings(SETTINGS_LOCATION, refresh=True)
+
     def setUp(self):
         random.seed(42)
         self.character1 = Character('Evie')
@@ -143,7 +147,7 @@ class GameTestCase(unittest.TestCase):
         self.pg = Game()
         self.pg.add_character(self.character1)
         self.pg.add_character(self.character2)
-        self.pg.setup_game(SETTINGS_LOCATION)
+        self.pg.setup_game(self.settings)
 
     def test_all_one_colour(self):
         card_names = ['London', 'Oxford', 'Cambridge', 'Brighton', 'Southampton']


### PR DESCRIPTION
Provided ability for manual configuration of some game parameters.
Now it is possible to initialize `GameController` instance with several keyword arguments e.g.:

```python
controller = GameController(random_state=42, players=['Alice', 'Bob'], epidemics=5)
```

Alternatively, one can configure game parameters with `GameController.setup()` method:

```python
settings = {
    'random_state': 42,
    'players': ['Alice', 'Bob'],
    'epidemics': 5,
}
controller.setup(settings)
```

It makes sense to define the following parameters:

- `random_state`: integer for seeding random actions,
- `players`: an ordered list of player names,
- `epidemics`: difficulty level.

No validation provided for the input parameters at the moment.