### PR TITLE
Card-oriented game logic improvements

### DIFF
--- a/pyndemic/card.py
+++ b/pyndemic/card.py
@@ -1,5 +1,7 @@
 from .core import GameEntity
 
+
+# TODO: add more test cases for this module
 class Card(GameEntity):
     def __init__(self, name, colour):
         self.name = name
@@ -8,10 +10,52 @@ class Card(GameEntity):
     def __str__(self):
         return f'Card "{self.name}-{self.colour}"'
 
+    def on_draw(self, character_drawing):
+        pass
+
+    def on_play(self, character_playing):
+        pass
+
+    def on_discard(self, character_discarding):
+        pass
+
 
 class PlayerCard(Card):
     pass
 
 
+class CityCard(PlayerCard):
+    def on_draw(self, character_drawing):
+        character_drawing.add_card(self)
+        self.emit_signal(
+            f'{character_drawing} got {self}.',
+        )
+
+
+class EpidemicCard(PlayerCard):
+    def on_draw(self, character_drawing):
+        super().on_draw(character_drawing)
+
+        self.emit_signal(
+            f'{character_drawing} drew Epidemic!',
+        )
+
+        self.game = self._ctx['controller']().game
+        self.game.epidemic_phase()
+
+
+class ActionCard(PlayerCard):
+    def on_draw(self, character_drawing):
+        character_drawing.add_card(self)
+        self.emit_signal(
+            f'{character_drawing} got {self}.',
+        )
+
+
 class InfectCard(Card):
-    pass
+    def on_draw(self, character_drawing):
+        super().on_draw(character_drawing)
+
+        self.game = self._ctx['controller']().game
+        city = self.game.city_map[self.name]
+        self.game.infect_city(self.name, self.colour)

--- a/pyndemic/card.py
+++ b/pyndemic/card.py
@@ -21,18 +21,22 @@ class Card(GameEntity):
 
 
 class PlayerCard(Card):
-    pass
-
-
-class CityCard(PlayerCard):
     def on_draw(self, character_drawing):
         character_drawing.add_card(self)
         self.emit_signal(
-            f'{character_drawing} got {self}.',
+            f'{character_drawing} drew {self}.',
         )
 
 
+class CityCard(PlayerCard):
+    pass
+
+
 class EpidemicCard(PlayerCard):
+    def __init__(self):
+        self.name = 'Epidemic'
+        self.colour = None
+
     def on_draw(self, character_drawing):
         super().on_draw(character_drawing)
 
@@ -45,11 +49,9 @@ class EpidemicCard(PlayerCard):
 
 
 class ActionCard(PlayerCard):
-    def on_draw(self, character_drawing):
-        character_drawing.add_card(self)
-        self.emit_signal(
-            f'{character_drawing} got {self}.',
-        )
+    def __init__(self, name):
+        self.name = name
+        self.colour = None
 
 
 class InfectCard(Card):

--- a/pyndemic/card.py
+++ b/pyndemic/card.py
@@ -1,7 +1,6 @@
 from .core import GameEntity
 
 
-# TODO: add more test cases for this module
 class Card(GameEntity):
     def __init__(self, name, colour):
         self.name = name
@@ -10,13 +9,13 @@ class Card(GameEntity):
     def __str__(self):
         return f'Card "{self.name}-{self.colour}"'
 
-    def on_draw(self, character_drawing):
+    def on_draw(self, *args, **kwargs):
         pass
 
-    def on_play(self, character_playing):
+    def on_play(self, *args, **kwargs):
         pass
 
-    def on_discard(self, character_discarding):
+    def on_discard(self, *args, **kwargs):
         pass
 
 
@@ -38,14 +37,12 @@ class EpidemicCard(PlayerCard):
         self.colour = None
 
     def on_draw(self, character_drawing):
-        super().on_draw(character_drawing)
-
         self.emit_signal(
             f'{character_drawing} drew Epidemic!',
         )
 
-        self.game = self._ctx['controller']().game
-        self.game.epidemic_phase()
+        game = self._ctx['controller']().game
+        game.epidemic_phase()
 
 
 class ActionCard(PlayerCard):
@@ -56,8 +53,10 @@ class ActionCard(PlayerCard):
 
 class InfectCard(Card):
     def on_draw(self, character_drawing):
-        super().on_draw(character_drawing)
+        self.on_play(character_drawing)
 
-        self.game = self._ctx['controller']().game
-        city = self.game.city_map[self.name]
-        self.game.infect_city(self.name, self.colour)
+    def on_play(self, character_playing):
+        game = self._ctx['controller']().game
+        game.infect_city(self.name, self.colour)
+        game.outbreak_stack.clear()
+        game.infect_deck.add_discard(self)

--- a/pyndemic/core/game_entity.py
+++ b/pyndemic/core/game_entity.py
@@ -52,7 +52,7 @@ class GameEntity(metaclass=GameEntityCreationMeta):
                 (f'Cannot find signal receiver for this object {self} - '
                  'game context is empty.'))
 
-        controller = self._ctx['controller']
+        controller = self._ctx['controller']()
 
         if isinstance(message, str):
             signal = api.message_response(message)

--- a/pyndemic/deck.py
+++ b/pyndemic/deck.py
@@ -2,8 +2,14 @@ import random
 from itertools import cycle, chain
 import logging
 
+from .exceptions import GameCrisisException
 from .core import GameEntity
-from .card import PlayerCard, InfectCard
+from .card import CityCard, InfectCard, EpidemicCard
+
+
+class ExhaustedPlayerDeckException(GameCrisisException):
+    def __str__(self):
+        return 'Player deck exhausted!'
 
 
 class Deck(GameEntity):
@@ -38,12 +44,30 @@ class Deck(GameEntity):
     def shuffle(self):
         random.shuffle(self.cards)
 
+    # TODO: test method
+    def draw_card(self, drawing_character, *, on_draw=True):
+        """Draws a card from the deck.
+        If `on_draw` parameter is set to False, the card object will not
+        perform its on-draw action.
+        """
+        try:
+            drawn_card = self.take_top_card()
+        except IndexError:
+            return self.on_deck_exhausted(drawing_character)
+
+        if on_draw:
+            drawn_card.on_draw(drawing_character)
+        return drawn_card
+
+    def on_deck_exhausted(self, drawing_character):
+        return None
+
 
 class PlayerDeck(Deck):
     def prepare(self, cities):
         self.clear()
         for city in cities:
-            new_card = PlayerCard(city.name, city.colour)
+            new_card = CityCard(city.name, city.colour)
             self.add_card(new_card)
 
         logging.debug(
@@ -60,13 +84,16 @@ class PlayerDeck(Deck):
                 break
 
         for pile in card_piles:
-            epidemic_card = PlayerCard('Epidemic', 'no-colour')
+            epidemic_card = EpidemicCard()
             place_to_insert = random.randint(0, len(pile))
             pile.insert(place_to_insert, epidemic_card)
 
         self.cards = list(chain(*card_piles))
         logging.debug(
             f'Added {number_epidemics} Epidemics to {self}.')
+
+    def on_deck_exhausted(self, drawing_character):
+        raise ExhaustedPlayerDeckException
 
 
 class InfectDeck(Deck):

--- a/pyndemic/deck.py
+++ b/pyndemic/deck.py
@@ -38,13 +38,14 @@ class Deck(GameEntity):
     def add_card(self, new_card):
         self.cards.append(new_card)
 
-    def add_discard(self, discarded_card):
+    def add_discard(self, discarded_card, *, on_discard=True):
+        if on_discard:
+            discarded_card.on_discard()
         self.discard.append(discarded_card)
 
     def shuffle(self):
         random.shuffle(self.cards)
 
-    # TODO: test method
     def draw_card(self, drawing_character, *, on_draw=True):
         """Draws a card from the deck.
         If `on_draw` parameter is set to False, the card object will not

--- a/pyndemic/game.py
+++ b/pyndemic/game.py
@@ -9,11 +9,6 @@ from .deck import PlayerDeck, InfectDeck
 from .disease import Disease
 
 
-class ExhaustedPlayerDeckException(GameCrisisException):
-    def __str__(self):
-        return 'Player deck exhausted!'
-
-
 class DeathOutbreakLevelException(GameCrisisException):
     def __str__(self):
         return 'Number of outbreaks reached death level!'
@@ -84,24 +79,6 @@ class Game(GameEntity):
         self.emit_signal(
             f'Added new {new_character}.',
         )
-
-    def draw_card(self, character_drawing):
-        try:
-            drawn_card = self.player_deck.take_top_card()
-        except IndexError:
-            raise ExhaustedPlayerDeckException
-
-        if drawn_card.name == 'Epidemic':
-            self.emit_signal(
-                f'{character_drawing} drew Epidemic!',
-            )
-
-            self.epidemic_phase()
-        else:
-            character_drawing.add_card(drawn_card)
-            self.emit_signal(
-                f'{character_drawing} got {drawn_card}.',
-            )
 
     def shuffle_decks(self):
         self.infect_deck.shuffle()
@@ -189,7 +166,7 @@ class Game(GameEntity):
         self.emit_signal('No actions left. Now getting cards...')
 
         for i in range(2):
-            self.draw_card(character)
+            self.player_deck.draw_card(character)
 
         self.emit_signal('Cards drawn. Now starting infect phase.')
 
@@ -269,7 +246,7 @@ class Game(GameEntity):
         self.epidemic_count += 1
         self.infection_rate = int(self.infection_rates[self.epidemic_count])
         self.emit_signal(
-            f'Incremented infection rate (now {self.infection_rate}).',
+            f'Infection rate incremented (now {self.infection_rate}).',
         )
 
     def draw_initial_hands(self):
@@ -282,4 +259,4 @@ class Game(GameEntity):
 
         for character in self.characters:
             for i in range(cards_to_draw):
-                self.draw_card(character)
+                self.player_deck.draw_card(character)

--- a/pyndemic/game.py
+++ b/pyndemic/game.py
@@ -147,11 +147,7 @@ class Game(GameEntity):
         )
 
         for i in range(self.infection_rate):
-            drawn_card = self.infect_deck.take_top_card()
-            self.infect_deck.add_discard(drawn_card)
-            infected_city = self.city_map.get(drawn_card.name)
-            self.infect_city(infected_city.name, infected_city.colour)
-            self.outbreak_stack.clear()
+            self.infect_deck.draw_card(self.active_character)
 
         self.emit_signal('Infect phase finished.')
 

--- a/test/test_card.py
+++ b/test/test_card.py
@@ -1,20 +1,73 @@
 from unittest import TestCase
+from unittest.mock import patch
 
-from pyndemic.card import Card, PlayerCard, CityCard, EpidemicCard
-from pyndemic.game import Game
-from .test_helpers import MockController
+from pyndemic.card import (Card, PlayerCard, CityCard, EpidemicCard,
+                           ActionCard, InfectCard)
+from pyndemic.character import Character
+from .test_helpers import construct_mock_context
 
 
 class CardTestCase(TestCase):
-    def setUp(self):
-        self.controller = MockController()
-        self._ctx = self.controller._ctx
-
-        self.pg = Game()
-        self.pg.settings = self.controller.settings
-        self.controller.game = self.pg
-
     def test_init(self):
         card = Card('London', 'Blue')
         self.assertEqual('London', card.name)
         self.assertEqual('Blue', card.colour)
+
+
+class PlayerCardTestCase(TestCase):
+    def setUp(self):
+        self.character = Character('Bob')
+
+    def test_on_draw(self):
+        card = PlayerCard('London', 'Blue')
+        card.on_draw(self.character)
+        self.assertIn(card, self.character.hand)
+
+
+class CityCardTestCase(TestCase):
+    pass
+
+
+class EpidemicCardTestCase(TestCase):
+    def setUp(self):
+        self._ctx = construct_mock_context()
+        self.mock_game = self._ctx['controller']().game
+
+    def test_init(self):
+        card = EpidemicCard()
+        self.assertEqual('Epidemic', card.name)
+        self.assertIsNone(card.colour)
+
+    def test_on_draw(self):
+        card = EpidemicCard()
+        card.on_draw('Fake character')
+
+        self.mock_game.epidemic_phase.assert_called()
+
+
+class ActionCardTestCase(TestCase):
+    def test_init(self):
+        card = ActionCard('Special action')
+        self.assertEqual('Special action', card.name)
+        self.assertIsNone(card.colour)
+
+
+class InfectCardTestCase(TestCase):
+    def setUp(self):
+        self._ctx = construct_mock_context()
+        self.mock_game = self._ctx['controller']().game
+
+    @patch.object(InfectCard, 'on_play')
+    def test_on_draw(self, mock_method):
+        card = InfectCard('London', 'Blue')
+        card.on_draw('Fake character')
+
+        mock_method.assert_called_with('Fake character')
+
+    def test_on_play(self):
+        card = InfectCard('London', 'Blue')
+        card.on_play('Fake character')
+
+        self.mock_game.infect_city.assert_called_with(card.name, card.colour)
+        self.mock_game.outbreak_stack.clear.assert_called()
+        self.mock_game.infect_deck.add_discard.assert_called_with(card)

--- a/test/test_card.py
+++ b/test/test_card.py
@@ -1,6 +1,6 @@
 from unittest import TestCase
 
-from pyndemic.card import Card
+from pyndemic.card import Card, PlayerCard, CityCard, EpidemicCard
 from pyndemic.game import Game
 from .test_helpers import MockController
 

--- a/test/test_card.py
+++ b/test/test_card.py
@@ -1,9 +1,19 @@
 from unittest import TestCase
 
 from pyndemic.card import Card
+from pyndemic.game import Game
+from .test_helpers import MockController
 
 
 class CardTestCase(TestCase):
+    def setUp(self):
+        self.controller = MockController()
+        self._ctx = self.controller._ctx
+
+        self.pg = Game()
+        self.pg.settings = self.controller.settings
+        self.controller.game = self.pg
+
     def test_init(self):
         card = Card('London', 'Blue')
         self.assertEqual('London', card.name)

--- a/test/test_character.py
+++ b/test/test_character.py
@@ -6,9 +6,7 @@ from pyndemic.exceptions import *
 from pyndemic.game import Game
 from pyndemic.card import PlayerCard
 from pyndemic.character import Character
-
-
-SETTINGS_LOCATION = op.join(op.dirname(__file__), 'test_settings.cfg')
+from .test_helpers import SETTINGS_LOCATION
 
 
 class CharacterTestCase(TestCase):

--- a/test/test_character.py
+++ b/test/test_character.py
@@ -4,7 +4,7 @@ import os.path as op
 from pyndemic import config
 from pyndemic.exceptions import *
 from pyndemic.game import Game
-from pyndemic.card import PlayerCard
+from pyndemic.card import CityCard
 from pyndemic.character import Character
 from .test_helpers import SETTINGS_LOCATION
 
@@ -31,8 +31,8 @@ class CharacterTestCase(TestCase):
         self.assertEqual(0, character.action_count)
 
     def test_get_card(self):
-        self.character.hand = [PlayerCard('London', 'Blue'),
-                               PlayerCard('New York', 'Yellow')]
+        self.character.hand = [CityCard('London', 'Blue'),
+                               CityCard('New York', 'Yellow')]
 
         card = self.character.get_card('London')
         self.assertIs(self.character.hand[0], card)
@@ -47,14 +47,14 @@ class CharacterTestCase(TestCase):
         self.assertTrue(self.character.hand_contains('London'))
 
     def test_hand_contains(self):
-        self.character.hand = [PlayerCard('London', 'Blue'),
-                               PlayerCard('New York', 'Yellow')]
+        self.character.hand = [CityCard('London', 'Blue'),
+                               CityCard('New York', 'Yellow')]
 
         self.assertTrue(self.character.hand_contains('New York'))
         self.assertFalse(self.character.hand_contains('Oxford'))
 
     def test_discard_card(self):
-        self.game.draw_card(self.character)
+        self.game.player_deck.draw_card(self.character)
         card = self.character.hand[0]
 
         success = self.character.discard_card(card.name)
@@ -76,8 +76,8 @@ class CharacterTestCase(TestCase):
         self.character.action_count = 1
         self.assertFalse(self.character.check_charter_flight('London'))
 
-        self.character.hand = [PlayerCard('London', 'Blue'),
-                               PlayerCard('Moscow', 'Black')]
+        self.character.hand = [CityCard('London', 'Blue'),
+                               CityCard('Moscow', 'Black')]
         self.assertTrue(self.character.check_charter_flight('London'))
         self.assertFalse(self.character.check_charter_flight('Moscow'))
 
@@ -91,7 +91,7 @@ class CharacterTestCase(TestCase):
     def test_charter_flight(self):
         self.character.set_location('London')
         self.character.action_count = 4
-        self.game.draw_card(self.character)
+        self.game.player_deck.draw_card(self.character)
         card = self.character.hand[0]
 
         success = self.character.charter_flight(card.name, 'New York')
@@ -110,7 +110,7 @@ class CharacterTestCase(TestCase):
 
     def test_check_direct_flight(self):
         self.character.set_location('London')
-        self.character.hand = [PlayerCard('Moscow', 'Black')]
+        self.character.hand = [CityCard('Moscow', 'Black')]
         self.character.action_count = 4
 
         self.assertFalse(self.character.check_direct_flight('London', 'Bejing'))
@@ -123,7 +123,7 @@ class CharacterTestCase(TestCase):
     def test_direct_flight(self):
         self.character.set_location('Moscow')
         self.character.action_count = 4
-        self.game.draw_card(self.character)
+        self.game.player_deck.draw_card(self.character)
         card = self.character.hand[0]
 
         success = self.character.direct_flight('Moscow', card.name)
@@ -142,7 +142,7 @@ class CharacterTestCase(TestCase):
 
     def test_check_cure_disease(self):
         for i in range(9):
-            self.game.draw_card(self.character)
+            self.game.player_deck.draw_card(self.character)
         location = self.game.city_map['London']
         self.character.set_location('London')
 
@@ -164,7 +164,7 @@ class CharacterTestCase(TestCase):
 
     def test_cure_disease(self):
         for i in range(9):
-            self.game.draw_card(self.character)
+            self.game.player_deck.draw_card(self.character)
         location = self.game.city_map['London']
         self.character.set_location('London')
 
@@ -188,7 +188,7 @@ class CharacterTestCase(TestCase):
 
     def test_game_won(self):
         for i in range(9):
-            self.game.draw_card(self.character)
+            self.game.player_deck.draw_card(self.character)
         location = self.game.city_map['London']
         self.character.set_location('London')
 
@@ -204,8 +204,8 @@ class CharacterTestCase(TestCase):
             success = self.character.cure_disease(*card_names)
 
     def test_check_share_knowledge(self):
-        self.character.hand = [PlayerCard('London', 'Blue'),
-                               PlayerCard('Moscow', 'Black')]
+        self.character.hand = [CityCard('London', 'Blue'),
+                               CityCard('Moscow', 'Black')]
 
         self.character.set_location('London')
         self.other_character.set_location('London')
@@ -227,8 +227,8 @@ class CharacterTestCase(TestCase):
         self.assertFalse(self.character.check_share_knowledge('New York', self.other_character))
 
     def test_share_knowledge(self):
-        shared_card = PlayerCard('London', 'Blue')
-        unshared_card = PlayerCard('Moscow', 'Black')
+        shared_card = CityCard('London', 'Blue')
+        unshared_card = CityCard('Moscow', 'Black')
         self.character.hand = [shared_card, unshared_card]
 
         self.character.set_location('London')
@@ -359,8 +359,8 @@ class CharacterTestCase(TestCase):
         self.character.set_location('London')
         self.character.action_count = 4
 
-        self.character.hand = [PlayerCard('London', 'Blue'),
-                               PlayerCard('Moscow', 'Black')]
+        self.character.hand = [CityCard('London', 'Blue'),
+                               CityCard('Moscow', 'Black')]
 
         self.assertTrue(self.character.check_build_lab())
 
@@ -378,7 +378,7 @@ class CharacterTestCase(TestCase):
     def test_build_lab(self):
         location = self.game.city_map['London']
         location.has_lab = False
-        card = PlayerCard('London', 'Blue')
+        card = CityCard('London', 'Blue')
         self.character.hand.append(card)
         self.character.set_location('London')
         self.character.action_count = 4
@@ -392,7 +392,7 @@ class CharacterTestCase(TestCase):
 
         location = self.game.city_map['Moscow']
         lab_status = location.has_lab
-        card = PlayerCard('Moscow', 'Black')
+        card = CityCard('Moscow', 'Black')
         self.character.hand.append(card)
         self.character.set_location('Moscow')
         self.character.action_count = 0

--- a/test/test_commands.py
+++ b/test/test_commands.py
@@ -18,6 +18,9 @@ class CommandTestCase(unittest.TestCase):
         self.character = Mock()
         self.command = Command(self.game, self.character, self.controller)
 
+    def tearDown(self):
+        del self.controller
+
     def test_check_valid_command(self):
         # empty argument
         response = self.command.check_valid_command("")
@@ -41,6 +44,9 @@ class MoveCommandTestCase(unittest.TestCase):
         self.character.standard_move = MagicMock(return_value=True)
 
         self.command = MoveCommand(self.game, self.character, self.controller)
+
+    def tearDown(self):
+        del self.controller
 
     def test_check_valid_command(self):
         # irrelevant command
@@ -93,6 +99,9 @@ class FlyCommandTestCase(unittest.TestCase):
 
         self.command = FlyCommand(self.game, self.character, self.controller)
 
+    def tearDown(self):
+        del self.controller
+
     def test_check_valid_command(self):
         # irrelevant command
         command = dict(command='move', args={})
@@ -144,6 +153,9 @@ class CharterCommandTestCase(unittest.TestCase):
 
         self.command = CharterCommand(self.game, self.character,
                                       self.controller)
+
+    def tearDown(self):
+        del self.controller
 
     def test_check_valid_command(self):
         # irrelevant command
@@ -198,6 +210,9 @@ class ShuttleCommandTestCase(unittest.TestCase):
         self.command = ShuttleCommand(self.game, self.character,
                                       self.controller)
 
+    def tearDown(self):
+        del self.controller
+
     def test_check_valid_command(self):
         # irrelevant command
         command = dict(command='move', args={})
@@ -250,6 +265,9 @@ class BuildCommandTestCase(unittest.TestCase):
         self.command = BuildCommand(self.game, self.character,
                                     self.controller)
 
+    def tearDown(self):
+        del self.controller
+
     def test_check_valid_command(self):
         # irrelevant command
         command = dict(command='move', args={})
@@ -273,6 +291,9 @@ class TreatCommandTestCase(unittest.TestCase):
 
         self.command = TreatCommand(self.game, self.character,
                                     self.controller)
+
+    def tearDown(self):
+        del self.controller
 
     def test_check_valid_command(self):
         # irrelevant command
@@ -326,6 +347,9 @@ class CureCommandTestCase(unittest.TestCase):
         self.command = CureCommand(self.game, self.character,
                                    self.controller)
 
+    def tearDown(self):
+        del self.controller
+
     def test_check_valid_command(self):
         # irrelevant command
         command = dict(command='move', args={})
@@ -378,6 +402,9 @@ class ShareCommandTestCase(unittest.TestCase):
 
         self.command = ShareCommand(self.game, self.character,
                                     self.controller)
+
+    def tearDown(self):
+        del self.controller
 
     def test_check_valid_command(self):
         # irrelevant command
@@ -459,6 +486,9 @@ class PassCommandTestCase(unittest.TestCase):
 
         self.command = PassCommand(self.game, self.character,
                                     self.controller)
+
+    def tearDown(self):
+        del self.controller
 
     def test_check_valid_command(self):
         # irrelevant command

--- a/test/test_controller.py
+++ b/test/test_controller.py
@@ -4,7 +4,7 @@ from unittest.mock import patch, Mock, MagicMock
 from io import StringIO
 import os.path as op
 
-from pyndemic.game import ExhaustedPlayerDeckException
+from pyndemic.deck import ExhaustedPlayerDeckException
 from pyndemic.character import LastDiseaseCuredException
 from pyndemic.core import api
 from pyndemic.ui.console import ConsoleUI

--- a/test/test_controller.py
+++ b/test/test_controller.py
@@ -20,7 +20,6 @@ class GameControllerTestCase(TestCase):
         self.controller = GameController(random_state=42)
 
     def tearDown(self):
-        _ContextManager._contexts.clear()
         del self.controller
 
     def test_init(self):
@@ -29,7 +28,7 @@ class GameControllerTestCase(TestCase):
         ctx_id = ctx['id']
         self.assertIn(ctx_id, _ContextManager._contexts)
         self.assertIs(ctx, _ContextManager._contexts[ctx_id])
-        self.assertIs(self.controller, ctx['controller'])
+        self.assertIs(self.controller, ctx['controller']())
 
     @patch('pyndemic.controller.Game')
     def test_start_game(self, game_class):

--- a/test/test_core/test_context.py
+++ b/test/test_core/test_context.py
@@ -5,6 +5,8 @@ from pyndemic.core.context import (ContextError, ContextNotFoundError,
                                    get_context, generate_id, search_context,
                                    ContextRegistrationMeta, _ContextManager)
 
+# TODO: fix strange bug (reproduced when running unit tests twice or more)
+
 
 class ContextManagerTestCase(TestCase):
     """A comprehensive test for registering, getting, and unregistering
@@ -110,5 +112,5 @@ class ContextRegistrationMetaTestCase(TestCase):
         self.assertIn(context_id, self.contexts)
         self.assertIs(self.contexts[context_id], ctx)
 
-        ctx_registered_instance = ctx['test_context']
+        ctx_registered_instance = ctx['test_context']()
         self.assertIs(ctx_registered_instance, instance)

--- a/test/test_core/test_context.py
+++ b/test/test_core/test_context.py
@@ -1,11 +1,10 @@
 from unittest import TestCase
+import gc
 
 from pyndemic.core.context import (ContextError, ContextNotFoundError,
                                    register_context, unregister_context,
                                    get_context, generate_id, search_context,
                                    ContextRegistrationMeta, _ContextManager)
-
-# TODO: fix strange bug (reproduced when running unit tests twice or more)
 
 
 class ContextManagerTestCase(TestCase):
@@ -18,6 +17,7 @@ class ContextManagerTestCase(TestCase):
         self.contexts = _ContextManager._contexts
 
     def tearDown(self):
+        gc.collect()
         self.contexts.clear()
 
     def test_register_context(self):
@@ -87,6 +87,7 @@ class ContextRegistrationMetaTestCase(TestCase):
         self.contexts = _ContextManager._contexts
 
     def tearDown(self):
+        gc.collect()
         self.contexts.clear()
 
     def test_init(self):

--- a/test/test_core/test_game_entity.py
+++ b/test/test_core/test_game_entity.py
@@ -1,5 +1,6 @@
 from unittest import TestCase
 from collections import deque
+import weakref
 
 from pyndemic.core.context import ContextError
 from pyndemic.core import api
@@ -45,7 +46,8 @@ class GameEntityTestCase(TestCase):
     def setUp(self):
         controller_class = self.construct_controller_mock_class()
         self.controller = controller_class()
-        self._ctx = {'id': 'mock_context', 'controller': self.controller}
+        self._ctx = {'id': 'mock_context',
+                     'controller': weakref.ref(self.controller)}
 
     def test_assert_has_context(self):
         entity = GameEntity()

--- a/test/test_deck.py
+++ b/test/test_deck.py
@@ -5,10 +5,18 @@ import random
 from pyndemic.city import City
 from pyndemic.card import Card, PlayerCard, InfectCard
 from pyndemic.deck import Deck, PlayerDeck, InfectDeck
+from pyndemic.game import Game
+from .test_helpers import MockController
 
 
 class DeckTestCase(TestCase):
     def setUp(self):
+        self.controller = MockController()
+        self._ctx = self.controller._ctx
+        self.game = Game()
+        self.controller.game = self.game
+        self.game.settings = self.controller.settings
+
         self.deck = Deck()
         self.test_cards = [
             Card('London', 'Blue'),
@@ -18,6 +26,9 @@ class DeckTestCase(TestCase):
             Card('New York', 'Yellow'),
         ]
         self.deck.cards = self.test_cards.copy()
+
+    def tearDown(self):
+        del self.controller
 
     def test_clear(self):
         self.deck.clear()
@@ -89,7 +100,16 @@ class PlayerDeckTestCase(TestCase):
         cls.cities = TEST_CITIES
 
     def setUp(self):
+        self.controller = MockController()
+        self._ctx = self.controller._ctx
+        self.game = Game()
+        self.controller.game = self.game
+        self.game.settings = self.controller.settings
+
         self.deck = PlayerDeck()
+
+    def tearDown(self):
+        del self.controller
 
     def test_prepare(self):
         self.deck.prepare(self.cities)
@@ -109,9 +129,10 @@ class PlayerDeckTestCase(TestCase):
         self.deck.prepare(self.cities)
 
         random.seed(42)
+        expected_deck_size = len(self.deck.cards) + 6
         self.deck.add_epidemics(6)
 
-        self.assertEqual(46, len(self.deck.cards))
+        self.assertEqual(expected_deck_size, len(self.deck.cards))
         self.assertEqual('Epidemic', self.deck.cards[13].name)
         self.assertEqual('Epidemic', self.deck.cards[24].name)
         self.assertEqual('London', self.deck.cards[33].name)

--- a/test/test_formatter.py
+++ b/test/test_formatter.py
@@ -1,13 +1,11 @@
 import unittest
 
-import os.path as op
 import random
 
-from pyndemic import config
 from pyndemic.game import Game
 from pyndemic.city import City
 from pyndemic.disease import Disease
-from pyndemic.card import Card, PlayerCard
+from pyndemic.card import Card, CityCard, EpidemicCard
 from pyndemic.deck import Deck
 from pyndemic.character import Character
 from pyndemic.formatter import BaseFormatter
@@ -67,24 +65,32 @@ class GameStateSerialisationCase(unittest.TestCase):
 
 
 class CardSerialisationTestCase(unittest.TestCase):
-    def setUp(self):
-        self.card = Card('London', 'Blue')
-
     def test_card_to_dict(self):
-        output = BaseFormatter.card_to_dict(self.card)
+        card = Card('London', 'Blue')
+        output = BaseFormatter.card_to_dict(card)
         self.assertEqual('London', output['name'])
         self.assertEqual('Blue', output['colour'])
+
+        card = CityCard('London', 'Blue')
+        output = BaseFormatter.card_to_dict(card)
+        self.assertEqual('London', output['name'])
+        self.assertEqual('Blue', output['colour'])
+
+        card = EpidemicCard()
+        output = BaseFormatter.card_to_dict(card)
+        self.assertEqual('Epidemic', output['name'])
+        self.assertIsNone(output['colour'])
 
 
 class DeckSerialisationTestCase(unittest.TestCase):
     def setUp(self):
         self.deck = Deck()
         self.test_cards = [
-            Card('London', 'Blue'),
-            Card('Washington', 'Yellow'),
-            Card('Bejing', 'Red'),
-            Card('Moscow', 'Black'),
-            Card('New York', 'Yellow'),
+            CityCard('London', 'Blue'),
+            CityCard('Washington', 'Yellow'),
+            CityCard('Bejing', 'Red'),
+            CityCard('Moscow', 'Black'),
+            CityCard('New York', 'Yellow'),
         ]
         self.deck.cards = self.test_cards.copy()
 
@@ -92,9 +98,9 @@ class DeckSerialisationTestCase(unittest.TestCase):
         self.deck.clear()
         self.assertEqual([], BaseFormatter.deck_to_list(self.deck))
 
-        discarded_card = Card('Cherepovets', 'Black')
+        discarded_card = CityCard('Cherepovets', 'Black')
         self.deck.add_discard(discarded_card)
-        discarded_card = Card('London', 'Blue')
+        discarded_card = CityCard('London', 'Blue')
         self.deck.add_discard(discarded_card)
         output = BaseFormatter.deck_to_list(self.deck)
         self.assertEqual('Cherepovets', output[0]['name'])
@@ -141,8 +147,8 @@ class CharacterSerialisationTestCase(unittest.TestCase):
         self.game.setup_game(self.controller.settings)
         self.character.set_location('London')
         self.character.action_count = 4
-        self.character.hand = [PlayerCard('London', 'Blue'),
-                               PlayerCard('New York', 'Yellow')]
+        self.character.hand = [CityCard('London', 'Blue'),
+                               CityCard('New York', 'Yellow')]
 
     def tearDown(self):
         del self.controller

--- a/test/test_game.py
+++ b/test/test_game.py
@@ -279,7 +279,7 @@ class GameTestCase(unittest.TestCase):
         self.assertTrue(self.pg.city_map['London'].has_lab)
 
         for i in range(10):
-            self.pg.draw_card(self.character1)
+            self.pg.player_deck.draw_card(self.character1)
         self.assertEqual(1, self.pg.epidemic_count)
 
     def test_initial_infect_phase(self):
@@ -304,14 +304,6 @@ class GameTestCase(unittest.TestCase):
             with self.subTest(i=i, character=character):
                 self.assertEqual(4, len(character.hand))
                 self.assertEqual(test_cards[i * 4 + 3].name, character.hand[3].name)
-
-    def test_draw_card(self):
-        self.pg.draw_card(self.character1)
-        self.assertEqual('London', self.character1.hand[0].name)
-
-        self.pg.player_deck.cards = []
-        with self.assertRaises(GameCrisisException):
-            self.pg.draw_card(self.character1)
 
     def test_get_new_disease(self):
         self.assertFalse(self.pg.diseases['Blue'].cured)

--- a/test/test_game.py
+++ b/test/test_game.py
@@ -4,24 +4,26 @@ from unittest import TestCase
 import os.path as op
 import random
 
-from pyndemic import config
 from pyndemic.exceptions import *
 from pyndemic.deck import PlayerDeck, InfectDeck
 from pyndemic.game import Game
 from pyndemic.character import Character
-
-
-SETTINGS_LOCATION = op.join(op.dirname(__file__), 'test_settings.cfg')
+from .test_helpers import MockController
 
 
 class GameSetupTestCase(TestCase):
-    @classmethod
-    def setUpClass(cls):
-        cls.settings = config.get_settings(SETTINGS_LOCATION, refresh=True)
-
     def setUp(self):
+        self.controller = MockController()
+        self._ctx = self.controller._ctx
+
         self.pg = Game()
+        self.controller.game = self.pg
+        self.settings = self.controller.settings
+
         self.pg.settings = self.settings
+
+    def tearDown(self):
+        del self.controller
 
     def test_add_character(self):
         characters = [Character('Evie'), Character('Amelia')]
@@ -136,18 +138,24 @@ class GameSetupTestCase(TestCase):
 
 
 class GameTestCase(unittest.TestCase):
-    @classmethod
-    def setUpClass(cls):
-        cls.settings = config.get_settings(SETTINGS_LOCATION, refresh=True)
 
     def setUp(self):
+        self.controller = MockController()
+        self._ctx = self.controller._ctx
+        self.settings = self.controller.settings
+
         random.seed(42)
         self.character1 = Character('Evie')
         self.character2 = Character('Amelia')
         self.pg = Game()
         self.pg.add_character(self.character1)
         self.pg.add_character(self.character2)
+
+        self.controller.game = self.pg
         self.pg.setup_game(self.settings)
+
+    def tearDown(self):
+        del self.controller
 
     def test_all_one_colour(self):
         card_names = ['London', 'Oxford', 'Cambridge', 'Brighton', 'Southampton']

--- a/test/test_helpers.py
+++ b/test/test_helpers.py
@@ -1,0 +1,17 @@
+import os.path as op
+from collections import deque
+
+from pyndemic.core.context import (ContextRegistrationMeta, unregister_context,
+                                   ContextNotFoundError)
+from pyndemic import config
+
+
+SETTINGS_LOCATION = op.join(op.dirname(__file__), 'test_settings.cfg')
+
+
+class MockController(metaclass=ContextRegistrationMeta,
+                     ctx_name='controller'):
+    """Help Controller-like class with "signals" and "_ctx" attributes."""
+    def __init__(self):
+        self.signals = deque()
+        self.settings = config.get_settings(SETTINGS_LOCATION, refresh=True)

--- a/test/test_helpers.py
+++ b/test/test_helpers.py
@@ -1,8 +1,7 @@
 import os.path as op
 from collections import deque
 
-from pyndemic.core.context import (ContextRegistrationMeta, unregister_context,
-                                   ContextNotFoundError)
+from pyndemic.core.context import ContextRegistrationMeta
 from pyndemic import config
 
 

--- a/test/test_helpers.py
+++ b/test/test_helpers.py
@@ -1,11 +1,16 @@
 import os.path as op
 from collections import deque
+from unittest.mock import MagicMock
 
 from pyndemic.core.context import ContextRegistrationMeta
 from pyndemic import config
 
 
 SETTINGS_LOCATION = op.join(op.dirname(__file__), 'test_settings.cfg')
+
+
+def construct_mock_context():
+    return {'id': 'foo', 'controller': MagicMock()}
 
 
 class MockController(metaclass=ContextRegistrationMeta,


### PR DESCRIPTION
I introduced the new way of triggering and performing card actions.
Now each Card subclass must implement at least three methods: `.on_draw`, `.on_play`, and `.on_discard`. These methods are called in the higher level game objects (e.g. Game, Deck, Character) and responsible for any actions (game logic or not) that must happen in these situations. We can treat these methods as event handlers.

Such a way helps by:
- making game components more clear (decoupling logic, decreasing if-blocks, etc.)
- simplifying unit testing,
- providing a good way for future implementation of independent and flexible game actions,
- making code structure better for development by multiple coders.

Here I made a number of card classes with their own handlers and changed the logic of performing some game actions (see refactored `Game.end_turn`, `Game.draw_card`, and `Game.infect_city_phase` as well as `Deck.draw_card` for example).
I updated tests in accordance with the new code and added some helper methods for testing.

Apart from that, I made small improvements and fixes in the `context` module.